### PR TITLE
made the default embed colors consistant

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -8,10 +8,10 @@
 	"dev_cmd_file_prefix": "$",
 	"colors": {
 		"embed": {
-			"default": "#980F91",
-			"error": "#FF5555",
-			"warn": "#FE9713",
-			"success": "#24A400"
+			"default": "#992699",
+			"error": "#992626",
+			"warn": "#995026",
+			"success": "#399926"
 		},
 		"tag": {
 			"null": "#C4AB79",


### PR DESCRIPTION
Default embed highlight colors are inconsistent in their saturation and do not look coherent when viewed side by side.
![image](https://user-images.githubusercontent.com/31388146/129459390-08aa25f7-d507-4971-a171-30237677e62c.png)